### PR TITLE
Update IBenchHelper.java

### DIFF
--- a/src/main/java/com/sapient/ibench/util/IBenchHelper.java
+++ b/src/main/java/com/sapient/ibench/util/IBenchHelper.java
@@ -23,14 +23,6 @@ public class IBenchHelper {
             iBench = player.getHeldItem();
         }
 
-        for (int i = 0; i < player.inventory.getSizeInventory(); i++) {
-            ItemStack stack = player.inventory.getStackInSlot(i);
-
-            if (stack != null && stack.getItem() != null && stack.getItem() instanceof ItemIBench) {
-                iBench = player.inventory.getStackInSlot(i);
-            }
-        }
-
         if (!player.worldObj.isRemote && iBench != null) {
             NBTHelper.setUUID(iBench);
         }

--- a/src/main/resources/assets/ibench/lang/en_US.lang
+++ b/src/main/resources/assets/ibench/lang/en_US.lang
@@ -6,7 +6,7 @@ item.ibench:crafting_core.name=Crafting Core
 item.ibench:crafting_core_plus.name=Crafting Core Plus
 
 # Creative tab Localization
-itemGroup.ibench=iBench
+itemGroup.iBench=iBench
 
 # Misc stuff
 crafting.iBench=iBench


### PR DESCRIPTION
Unless I am missing something, the extra check for any iBench in the player's inventory only serves to link up the inventories of any iBenches the player has (similar to an ender-chest). If you want it to act this way, disregard my pull request. But if you want each iBench instance/ItemStack to have it's own inventory, deleting that code does the trick.
